### PR TITLE
allows for declaration of uninitialized variables to align with style…

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ module.exports = {
     'keyword-spacing': [1, { 'before': true, 'after': true }],
     'space-infix-ops': 1,
     /* Variable declaration */
-    'one-var': [1, { 'uninitialized': 'always', 'initialized': 'never' }],
+    'one-var': [1, { 'uninitialized': 'never', 'initialized': 'never' }],
+    'no-use-before-define': 2,
     /* Minuta */
     'comma-style': [2, 'last'],
     'quotes': [1, 'single']


### PR DESCRIPTION
allows for declaration of uninitialized variables to align with Hack Reactor style guide (previously gave a warning when declaring an uninitialized variable)

disallows for variables to be used prior to declaration (previously allowed for variables to be declared without var)