### PR TITLE
Update ecmaVersion to 2018

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   parserOptions: {
     sourceType: 'module',
-    ecmaVersion: 6,
+    ecmaVersion: 2018,
     ecmaFeatures: {
       'jsx': true
     }


### PR DESCRIPTION
2017 allows for async/await syntax in a different project I am working on. https://github.com/eslint/eslint/issues/8126
2018 works just fine as well.
2019 breaks with `Parsing error: Invalid ecmaVersion` errors for a different project I am working on that is using `gulp-eslint v2.0.0` (`eslint v2.13.0`)